### PR TITLE
Fix all bugs

### DIFF
--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -20,9 +20,11 @@ interface ProductCardProps {
 }
 
 export const ProductCard = React.memo(({ product, onPress, style }: ProductCardProps) => {
-  const formatPrice = useMemo(() => (price: number) => {
-    return `€${price.toFixed(2)}`;
-  }, []);
+  /**
+   * Formats a numeric price value with the € currency symbol and exactly two decimals.
+   * Wrapped in useMemo so the formatter function is created only once.
+   */
+  const formatPrice = useMemo(() => (price: number) => `€${price.toFixed(2)}`, []);
 
   const getCategoryEmoji = useMemo(() => (category: string) => {
     switch (category) {
@@ -94,7 +96,9 @@ export const ProductCard = React.memo(({ product, onPress, style }: ProductCardP
           </View>
 
           <View style={styles.priceContainer}>
-            <Text style={styles.price}>€{product.price?.toFixed(2) || '--'}</Text>
+            <Text style={styles.price}>
+              {product.price != null ? formatPrice(product.price) : '€--'}
+            </Text>
           </View>
         </View>
       </View>


### PR DESCRIPTION
Utilize the existing `formatPrice` helper in `ProductCard.tsx` to resolve an unused variable linter warning.

The `formatPrice` helper was defined but not used, leading to a linter warning. This PR integrates the helper into the price rendering logic, ensuring consistent formatting and resolving the warning without changing existing behavior.

---

[Open in Web](https://www.cursor.com/agents?id=bc-f337a5d7-4de4-4939-a266-a3dba2f4fb69) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-f337a5d7-4de4-4939-a266-a3dba2f4fb69)